### PR TITLE
Updates for `Zabbix 5.0`

### DIFF
--- a/zbx_template_pdu_tripplite.xml
+++ b/zbx_template_pdu_tripplite.xml
@@ -704,10 +704,10 @@
             </macros>
             <templates>
                 <template>
-                    <name>Template SNMP Generic</name>
+                    <name>Template Module Generic SNMP</name>
                 </template>
                 <template>
-                    <name>Template SNMP Interfaces</name>
+                    <name>Template Module Interfaces SNMP</name>
                 </template>
             </templates>
             <screens/>


### PR DESCRIPTION
Minor template link updates (`Template` --> `Template Module` and `SNMP` goes at the end of the template name) for Zabbix 5.0 compatibility.

Signed-off-by: Layla <layla@insightfulvr.com>